### PR TITLE
Fix: NPE if unknown memSpace name.  emsg.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # astrology-castro - v0.1.0 early beta
-`castro` compiles a simple "C" like language into [Astrolog](https://www.astrolog.org) commands and [AstroExpressions](https://www.astrolog.org/ftp/astrolog.htm#express); `castro` is tailored to `AstroExpression` (WYSIWYG). `castro` is a standalone tool; its output is a `.as` file that can be used with `Astrolog`'s command switch `-i <filename>`. Some motivating factors for `castro` were familiar expression syntax (avoid writing and maintaining the prefix notation expressions), automatic memory allocation, referring to things by name rather than address.
+`castro` compiles a simple "C" like language into [Astrolog](https://www.astrolog.org) commands and [AstroExpressions](https://www.astrolog.org/ftp/astrolog.htm#express); `castro` is tailored to `AstroExpression` (and WYSIWYG). `castro` is a standalone tool; its output is a `.as` file that can be used with `Astrolog`'s command switch `-i <filename>`. Some motivating factors for `castro` were familiar expression syntax (avoid writing and maintaining the prefix notation expressions), automatic memory allocation, referring to things by name rather than address.
 
 Here's a simple example. Note that the switch, macro and variable definitions could be in 3 different files. As in `Astrolog`, function names are case insensitive. _Switch and macro names are case sensitive_.
 ```
@@ -237,7 +237,7 @@ Handle single file compilation, uses the .map file as input. Not sure this is an
 
 
 ##     Warnings/Oddities:
-- `True()`/`False()` are `Astrolog` _functions_; the `()` must be present.
+- `True()`/`False()` are `Astrolog` **functions**; the `()` must be present.
 - Some cases where blanks are significant
     - The functions `=Obj` and `=Hou` can cause problems, for example `a==Obj(...)` is parsed as `a == Obj(...)`,
       write `a= =Obj(...)` for assignment.

--- a/codegen/castro/src/main/java/com/raelity/astrolog/castro/Compile.java
+++ b/codegen/castro/src/main/java/com/raelity/astrolog/castro/Compile.java
@@ -4,7 +4,6 @@ package com.raelity.astrolog.castro;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -40,6 +39,11 @@ import static com.raelity.astrolog.castro.mems.AstroMem.Var.VarState.*;
  * Run the passes. <br>
  * Pass1 - Layout info, var/mem symbol tables, check func name/nargs,
  *         Build LineMap.
+ *              TODO: consider: split this pass into two: pass1a and pass1b.
+ *              pass1a parse without a visitor, don't continue if error.
+ *              The visitor that is now pass1 has lots of code to continue in
+ *              the face of error. But NPE might sneak through; so what?
+ * Allocation - between pass1 and pass2.
  * Pass2 - Check used variables are defined.
  *         Check no blanks in switch cmd, proper switch expression usage.
  * Pass3 - Generate code.

--- a/codegen/castro/src/main/java/com/raelity/astrolog/castro/Util.java
+++ b/codegen/castro/src/main/java/com/raelity/astrolog/castro/Util.java
@@ -236,6 +236,18 @@ public static void report(Error err, Token token, Object... msg)
         lookup(AstroParseResult.class).countError();
 }
 
+/** @return text encompassing token1:token2 */
+public static String getText(Token token1, Token token2)
+{
+    // assuming both tokens in same stream
+    try {
+        return token1.getInputStream().getText(
+                new Interval(token1.getStartIndex(), token2.getStopIndex()));
+    } catch(Exception ex) {
+        return ex.getMessage();
+    }
+}
+
 public static String getLineText(Token token)
 {
     if(token == null)

--- a/codegen/castro/src/main/java/com/raelity/astrolog/castro/mems/AstroMem.java
+++ b/codegen/castro/src/main/java/com/raelity/astrolog/castro/mems/AstroMem.java
@@ -200,7 +200,7 @@ public Layout getNewLayout()
         lr = new Layout(this);
         layoutRestrictions = lr;
     } else
-        lr = new Layout(null);
+        lr = new Layout();
     return lr;
 }
 

--- a/codegen/castro/src/main/java/com/raelity/astrolog/castro/mems/Layout.java
+++ b/codegen/castro/src/main/java/com/raelity/astrolog/castro/mems/Layout.java
@@ -29,6 +29,11 @@ public class Layout
         this.reserve = TreeRangeSet.create();
     }
 
+    public Layout()
+    {
+        this(null);
+    }
+
     public AstroMem getMem()
     {
         return mem;

--- a/grammar/AstroParser.g4
+++ b/grammar/AstroParser.g4
@@ -88,7 +88,7 @@ run
 
 switch_cmd
     : expr_arg=SW_ARG bs+=astroExprStatement + '}'   // express arg to regular switch
-    | name=sw_name '{' bs+=astroExprStatement + '}'
+    | name=sw_name b='{' bs+=astroExprStatement + '}'
     | name=sw_name
     | string=String
     //| assign=AssignString '(' l=lval ',' str+=String (',' str+=String)* ')'
@@ -112,7 +112,7 @@ sw_name
  * TODO: Give warning if line starts with '*', '+', '-'
  */
 astroExprStatement
-    : astroExpr opt_semi[($astroExpr.stop.getType() == Semi) ? 1 : 0]
+    : e=astroExpr opt_semi[($astroExpr.stop.getType() == Semi) ? 1 : 0]
     ;
 
 opt_semi[int fHasSemi]


### PR DESCRIPTION
Util.getText return text encompassing token1:token2. Better emsg for "-AAA { ~ a}" in pass2 exitSwitch_cmd().